### PR TITLE
Add referrerpolicy to youtube iframe

### DIFF
--- a/youtube-widget/youtube-video.htm
+++ b/youtube-widget/youtube-video.htm
@@ -18,6 +18,6 @@
 <dd>
     <iframe data-bind="attr: { src: YoutubeUrl }" width="560" height="315" title="YouTube video player" frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen></iframe>
+        allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
 </dd>
 {% endblock report %}


### PR DESCRIPTION
Youtube now requires you to specify the referrer policy in the iframe that holds the youtube link:

https://support.bolddesk.com/kb/article/23115/troubleshooting-youtube-error-153-issues-in-bolddesk

Closes: https://github.com/k-int/arches-kint-widgets/issues/4

